### PR TITLE
Single HCP

### DIFF
--- a/reco_analysis/notebooks/create_default_hcp.ipynb
+++ b/reco_analysis/notebooks/create_default_hcp.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Dev/Local -- restart ipynb env first\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"POSTGRES_DB_ENVIRONMENT\"] = \"DEV\"\n",
+    "\n",
+    "from reco_analysis.data_model import data_models\n",
+    "\n",
+    "session = data_models.get_session()\n",
+    "engine = data_models.get_engine()\n",
+    "assert \"localhost\" in str(engine.url)\n",
+    "\n",
+    "default_hcp = data_models.HealthcareProvider.create_default_healthcare_provider(session)\n",
+    "print(default_hcp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2024-07-06 17:57:10.667\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mreco_analysis.config\u001b[0m:\u001b[36m<module>\u001b[0m:\u001b[36m11\u001b[0m - \u001b[1mPROJ_ROOT path is: /Users/michaelenghoekhor/Documents/GitHub/reco/reco_analysis\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HealthcareProvider(id='6', first_name='Ray', last_name='ReCo', email='mike.khor@berkeley.edu', created_at='2024-07-06 09:57:14.744108', updated_at='2024-07-06 09:57:14.744108')\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Prod -- restart ipynb env first\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"POSTGRES_DB_ENVIRONMENT\"] = \"PROD\"\n",
+    "\n",
+    "from reco_analysis.data_model import data_models\n",
+    "\n",
+    "session = data_models.get_session()\n",
+    "engine = data_models.get_engine()\n",
+    "assert \"amazonaws\" in str(engine.url)\n",
+    "\n",
+    "default_hcp = data_models.HealthcareProvider.create_default_healthcare_provider(session)\n",
+    "print(default_hcp)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "reco-analysis-vNTlTR5M-py3.11",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/reco_analysis/reco_analysis/data_model/init_test_data.py
+++ b/reco_analysis/reco_analysis/data_model/init_test_data.py
@@ -45,6 +45,8 @@ def create_name() -> typing.Tuple[str, str]:
 
 
 def create_healthcare_providers(count=5):
+    HealthcareProvider.create_default_healthcare_provider()
+
     for _ in range(count):
         first_name, last_name = create_name()
         provider = HealthcareProvider(

--- a/reco_analysis/reco_analysis/data_model/init_test_data.py
+++ b/reco_analysis/reco_analysis/data_model/init_test_data.py
@@ -47,18 +47,6 @@ def create_name() -> typing.Tuple[str, str]:
 def create_healthcare_providers(count=5):
     HealthcareProvider.create_default_healthcare_provider(session=session)
 
-    for _ in range(count):
-        first_name, last_name = create_name()
-        provider = HealthcareProvider(
-            first_name=first_name,
-            last_name=last_name,
-            email=create_email(f"{first_name}.{last_name}"),
-            description="A dedicated healthcare professional.",
-            created_at=start_time,
-        )
-        session.add(provider)
-    session.commit()
-
 
 def create_patients(count=10):
     providers = session.query(HealthcareProvider).all()

--- a/reco_analysis/reco_analysis/data_model/init_test_data.py
+++ b/reco_analysis/reco_analysis/data_model/init_test_data.py
@@ -45,7 +45,7 @@ def create_name() -> typing.Tuple[str, str]:
 
 
 def create_healthcare_providers(count=5):
-    HealthcareProvider.create_default_healthcare_provider()
+    HealthcareProvider.create_default_healthcare_provider(session=session)
 
     for _ in range(count):
         first_name, last_name = create_name()


### PR DESCRIPTION
This PR creates a single default healthcare provider (HCP; using Mike's email address for now). Every new patient created will link to the default HCP if not specified. This is applicable to both development and production environments.

Reasoning: this simplifies RECO UI development, by not requiring a HCP sign-up page/workflow.